### PR TITLE
Compatibility with macOS 15

### DIFF
--- a/Sources/PerfectSQLite/SQLite.swift
+++ b/Sources/PerfectSQLite/SQLite.swift
@@ -23,6 +23,7 @@ import PerfectCSQLite3
 import SwiftGlibc
 #else
 import SQLite3
+import Darwin
 #endif
 
 /// This enum type indicates an exception when dealing with a SQLite database

--- a/Sources/PerfectSQLite/SQLiteCRUD.swift
+++ b/Sources/PerfectSQLite/SQLiteCRUD.swift
@@ -346,7 +346,7 @@ class SQLiteGenDelegate: SQLGenDelegate {
 		}
 		return "\(name) \(typeName)\(addendum)"
 	}
-	func getBinding(for expr: Expression) throws -> String {
+	func getBinding(for expr: CRUDExpression) throws -> String {
 		bindings.append(("?", expr))
 		return "?"
 	}


### PR DESCRIPTION
In macOS 15, a built-in type called Expression was introduced, causing an ambiguous type error.